### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # A-week-to-develop-android-app-plan
 # 一周开发Android App计划
 
-#概述
+# 概述
 现在开发app已经很成熟了，Android这样的一个平台，经过这些年广大的Android开发者的努力已经建立起了一个完整的生态，各种优秀开源项目，各种优秀的开源框架，各种优秀的开发教程，笔者只是移动浪潮中的一个小小开发者，独立开发不少项目，也想建立起自己的一个小生态，让自己做事情更加有效率，就做了这样的一个计划，假如有一个快速开发的框架，我能不能一周之内完成一个app的开发呢？我的答案是，完全可以啊，我们做了那么项目，总有很多东西是每个app都要有的，我们是不是可以把这些东西抽取出来做成组件放到一个组件库中，我们以后再开发一个新的app，我们就根据需求把我们用到的组件拿过来，减少了重复开发的劳动，我们可以更关注产品的业务，而不必做太多无用功，这是笔者的愿望，也希望我的这个举措能帮助深陷加班的开发者早日脱离苦海。
 
 
 
 ## 作者：小巫
 
-##编码要求
+## 编码要求
 - 按照开源规范来做，代码规范和Android开发规范
 - 必须拥有github账号，熟练使用git对代码进来管理
 - 一个功能点或模块一个项目
@@ -35,8 +35,8 @@
 [完整开发框架](https://github.com/fanatic-mobile-developer-for-android/A-week-to-develop-android-app-plan/tree/master/AndroidQuickStartProject)
 持续更新中。。。
 
-##关注我的github
+## 关注我的github
 [https://github.com/devilWwj](https://github.com/devilWwj)
 
-##移动开发狂热者github组织
+## 移动开发狂热者github组织
 [https://github.com/fanatic-mobile-developer-for-android/A-week-to-develop-android-app-plan](https://github.com/fanatic-mobile-developer-for-android/A-week-to-develop-android-app-plan)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
